### PR TITLE
Fix internal name for 'announced' minimum availability

### DIFF
--- a/buildarr_jellyseerr/config/settings/services/radarr.py
+++ b/buildarr_jellyseerr/config/settings/services/radarr.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 class MinimumAvailability(BaseEnum):
-    accounced = "announced"
+    announced = "announced"
     in_cinemas = "inCinemas"
     released = "released"
 


### PR DESCRIPTION
As the API version of the name is also accepted by Buildarr, this wasn't broken per se, but fix the unintentional typo regardless.