### PR TITLE
Add Jellyseerr instance URL base support

### DIFF
--- a/buildarr_jellyseerr/cli.py
+++ b/buildarr_jellyseerr/cli.py
@@ -67,6 +67,11 @@ def dump_config(url: Url, api_key: str) -> int:
     The configuration is dumped to standard output in Buildarr-compatible YAML format.
     """
 
+    if not api_key:
+        raise ValueError(
+            "An API key must be provided to authenticate with the Jellyseerr instance",
+        )
+
     protocol = url.scheme
     hostname_port = url.netloc.split(":", 1)
     hostname = hostname_port[0]
@@ -75,21 +80,22 @@ def dump_config(url: Url, api_key: str) -> int:
         if len(hostname_port) == HOSTNAME_PORT_TUPLE_LENGTH
         else (443 if protocol == "https" else 80)
     )
+    url_base = url.path
 
     instance_config = JellyseerrInstanceConfig(
         **{  # type: ignore[arg-type]
             "hostname": hostname,
             "port": port,
             "protocol": protocol,
+            "url_base": url_base,
         },
     )
-    secrets = JellyseerrSecrets(
-        **{  # type: ignore[arg-type]
-            "hostname": hostname,
-            "port": port,
-            "protocol": protocol,
-            "api_key": api_key,
-        },
+    secrets = JellyseerrSecrets.get_from_url(
+        hostname=hostname,
+        port=port,
+        protocol=protocol,
+        url_base=url_base,
+        api_key=api_key,
     )
 
     click.echo(

--- a/buildarr_jellyseerr/exceptions.py
+++ b/buildarr_jellyseerr/exceptions.py
@@ -38,3 +38,19 @@ class JellyseerrAPIError(JellyseerrError):
     def __init__(self, msg: str, status_code: int) -> None:
         self.status_code = status_code
         super().__init__(msg)
+
+
+class JellyseerrSecretsError(JellyseerrError):
+    """
+    Jellyseerr plugin secrets exception base class.
+    """
+
+    pass
+
+
+class JellyseerrSecretsUnauthorizedError(JellyseerrSecretsError):
+    """
+    Error raised when Buildarr was unable to authenticate with Jellyseerr.
+    """
+
+    pass

--- a/buildarr_jellyseerr/secrets.py
+++ b/buildarr_jellyseerr/secrets.py
@@ -20,14 +20,14 @@ Jellyseerr plugin secrets file model.
 from __future__ import annotations
 
 from http import HTTPStatus
-from typing import TYPE_CHECKING, cast
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from buildarr.secrets import SecretsPlugin
 from buildarr.types import NonEmptyStr, Port
+from pydantic import validator
 
 from .api import api_get
-from .exceptions import JellyseerrAPIError
+from .exceptions import JellyseerrAPIError, JellyseerrSecretsUnauthorizedError
 from .types import JellyseerrApiKey, JellyseerrProtocol
 
 if TYPE_CHECKING:
@@ -48,47 +48,103 @@ class JellyseerrSecrets(_JellyseerrSecrets):
     hostname: NonEmptyStr
     port: Port
     protocol: JellyseerrProtocol
+    url_base: Optional[str]
     api_key: JellyseerrApiKey
+    version: NonEmptyStr
 
     @property
     def host_url(self) -> str:
-        return f"{self.protocol}://{self.hostname}:{self.port}"
+        return self._get_host_url(
+            protocol=self.protocol,
+            hostname=self.hostname,
+            port=self.port,
+            url_base=self.url_base,
+        )
+
+    @validator("url_base")
+    def validate_url_base(cls, value: Optional[str]) -> Optional[str]:
+        return f"/{value.strip('/')}" if value and value.strip("/") else None
 
     @classmethod
-    def from_url(cls, base_url: str, api_key: str) -> Self:
-        url_obj = urlparse(base_url)
-        hostname_port = url_obj.netloc.rsplit(":", 1)
-        hostname = hostname_port[0]
-        protocol = url_obj.scheme
-        port = (
-            int(hostname_port[1])
-            if len(hostname_port) > 1
-            else (443 if protocol == "https" else 80)
-        )
-        return cls(
-            **{  # type: ignore[arg-type]
-                "hostname": hostname,
-                "port": port,
-                "protocol": protocol,
-                "api_key": api_key,
-            },
-        )
+    def _get_host_url(
+        cls,
+        protocol: str,
+        hostname: str,
+        port: int,
+        url_base: Optional[str],
+    ) -> str:
+        return f"{protocol}://{hostname}:{port}{url_base or ''}"
 
     @classmethod
     def get(cls, config: JellyseerrConfig) -> Self:
-        return cls(
+        return cls.get_from_url(
             hostname=config.hostname,
             port=config.port,
             protocol=config.protocol,
-            api_key=cast(JellyseerrApiKey, config.api_key),
+            url_base=config.url_base,
+            api_key=config.api_key.get_secret_value() if config.api_key else None,
+        )
+
+    @classmethod
+    def get_from_url(
+        cls,
+        hostname: str,
+        port: int,
+        protocol: str,
+        url_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> Self:
+        url_base = cls.validate_url_base(url_base)
+        host_url = cls._get_host_url(
+            protocol=protocol,
+            hostname=hostname,
+            port=port,
+            url_base=url_base,
+        )
+        if not api_key:
+            raise JellyseerrSecretsUnauthorizedError(
+                (
+                    "API key not found in the Buildarr configuration "
+                    f"for the Jellyseerr instance at '{host_url}'. "
+                    "Please check that the API key is set correctly, "
+                    "and that it is set to the value as shown in "
+                    "'Settings -> General -> API Key' on the Jellyseerr instance."
+                ),
+            )
+        try:
+            status = cast(Dict[str, Any], api_get(host_url, "/api/v1/status", api_key=api_key))
+        except JellyseerrAPIError as err:
+            if err.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+                raise JellyseerrSecretsUnauthorizedError(
+                    (
+                        f"Incorrect API key for the Jellyseerr instance at '{host_url}'. "
+                        "Please check that the API key is set correctly in the Buildarr "
+                        "configuration, and that it is set to the value as shown in "
+                        "'Settings -> General -> API Key' on the Jellyseerr instance."
+                    ),
+                ) from None
+            else:
+                raise
+        try:
+            version = cast(NonEmptyStr, status["version"])
+        except KeyError:
+            raise JellyseerrSecretsUnauthorizedError(
+                f"Unable to find Jellyseerr version in status metadata: {status}",
+            ) from None
+        except TypeError as err:
+            raise JellyseerrSecretsUnauthorizedError(
+                f"Unable to parse Jellyseerr status metadata: {err} (metadata object: {status})",
+            ) from None
+        return cls(
+            hostname=cast(NonEmptyStr, hostname),
+            port=cast(Port, port),
+            protocol=cast(JellyseerrProtocol, protocol),
+            url_base=url_base,
+            api_key=cast(JellyseerrApiKey, api_key),
+            version=version,
         )
 
     def test(self) -> bool:
-        try:
-            api_get(self, "/api/v1/settings/main")
-            return True
-        except JellyseerrAPIError as err:
-            if err.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
-                return False
-            else:
-                raise
+        # We already perform API requests as part of instantiating the secrets object.
+        # If the object exists, then the connection test is already successful.
+        return True

--- a/docs/configuration/host.md
+++ b/docs/configuration/host.md
@@ -6,6 +6,8 @@
         - hostname
         - port
         - protocol
+        - url_base
         - api_key
         - version
+        - image
         - settings


### PR DESCRIPTION
https://github.com/buildarr/buildarr-jellyseerr/issues/19

* Add the `url_base` host configuration attribute.
* When dumping host configurations, use the provided path as the URL base.
* Read and store the instance version as secrets metadata (instead of fetching it in a separate API request when creating the instance configuration).
* Check that the Jellyseerr API key has been provided when dumping instance configurations, and if not, return an error message to the user.
* Get the Buildarr-global request timeout value via the state attribute introduced in more recent versions of Buildarr.
* Add error handling for invalid JSON when parsing Jellyseerr API responses.