### PR TITLE
Make the Sonarr instance `animeAnimeDirectory` API field optional

### DIFF
--- a/buildarr_jellyseerr/config/settings/services/sonarr.py
+++ b/buildarr_jellyseerr/config/settings/services/sonarr.py
@@ -160,6 +160,7 @@ class Sonarr(ArrBase):
                 "anime_root_folder",
                 "activeAnimeDirectory",
                 {
+                    "optional": True,
                     "decoder": lambda v: v or None,
                     "encoder": lambda v: v or "",
                 },


### PR DESCRIPTION
#23

This fixes reading Sonarr instance configuration if no anime related configuration is defined, since in some cases Jellyseerr will not return a value in th API response at all if it is unset.