### PR TITLE
Updated to work with new API

### DIFF
--- a/buildarr_jellyseerr/config/settings/jellyfin.py
+++ b/buildarr_jellyseerr/config/settings/jellyfin.py
@@ -43,12 +43,12 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
     Server URL that Jellyseerr will use to communicate with Jellyfin.
     """
 
-    server_port: Optional[str] = None
+    port: Optional[str] = None
     """
     Server port that Jellyseerr will use to communicate with Jellyfin
     """
 
-    server_base_url: Optional[str] = None
+    base_url: Optional[str] = None
     """
     Server base URL that Jellyseerr will use to communicate with Jellyfin
     """
@@ -122,8 +122,8 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
                         "username": self.username,
                         "password": cast(SecretStr, self.password).get_secret_value(),
                         "hostname": self.server_url,
-                        "port": self.server_port,
-                        "urlBase": self.server_base_url,
+                        "port": self.port,
+                        "urlBase": self.base_url,
                         "email": self.email_address,
                     },
                     session=session,

--- a/buildarr_jellyseerr/config/settings/jellyfin.py
+++ b/buildarr_jellyseerr/config/settings/jellyfin.py
@@ -48,7 +48,7 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
     Server port that Jellyseerr will use to communicate with Jellyfin
     """
 
-    base_url: Optional[str] = None
+    url_base: Optional[str] = None
     """
     Server base URL that Jellyseerr will use to communicate with Jellyfin
     """
@@ -90,7 +90,7 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
         for attr_name in (
             "server_url",
             "port",
-            "base_url",
+            "url_base",
             "username",
             "password",
             "email_address",
@@ -126,7 +126,7 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
                         "password": cast(SecretStr, self.password).get_secret_value(),
                         "hostname": self.server_url,
                         "port": self.port,
-                        "urlBase": self.base_url,
+                        "urlBase": self.url_base,
                         "email": self.email_address,
                     },
                     session=session,

--- a/buildarr_jellyseerr/config/settings/jellyfin.py
+++ b/buildarr_jellyseerr/config/settings/jellyfin.py
@@ -24,7 +24,6 @@ from logging import getLogger
 from typing import Any, Dict, List, Optional, Set, Union, cast
 
 import requests
-
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr
 from pydantic import AnyHttpUrl, EmailStr, SecretStr
@@ -42,6 +41,16 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
     server_url: Optional[str] = None
     """
     Server URL that Jellyseerr will use to communicate with Jellyfin.
+    """
+
+    server_port: Optional[str] = None
+    """
+    Server port that Jellyseerr will use to communicate with Jellyfin
+    """
+
+    server_base_url: Optional[str] = None
+    """
+    Server base URL that Jellyseerr will use to communicate with Jellyfin
     """
 
     username: Optional[str] = None
@@ -78,7 +87,13 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
         # Check if we have all the information we need to initialise it.
         logger.info("Checking if required attributes are defined")
         missing_attrs: List[str] = []
-        for attr_name in ("server_url", "username", "password", "email_address", "libraries"):
+        for attr_name in (
+            "server_url",
+            "username",
+            "password",
+            "email_address",
+            "libraries",
+        ):
             attr_value: Optional[Union[str, SecretStr, Set[str]]] = getattr(self, attr_name)
             if isinstance(attr_value, SecretStr):
                 attr_value = attr_value.get_secret_value()
@@ -107,6 +122,8 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
                         "username": self.username,
                         "password": cast(SecretStr, self.password).get_secret_value(),
                         "hostname": self.server_url,
+                        "port": self.server_port,
+                        "urlBase": self.server_base_url,
                         "email": self.email_address,
                     },
                     session=session,

--- a/buildarr_jellyseerr/config/settings/jellyfin.py
+++ b/buildarr_jellyseerr/config/settings/jellyfin.py
@@ -89,6 +89,8 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
         missing_attrs: List[str] = []
         for attr_name in (
             "server_url",
+            "port",
+            "base_url",
             "username",
             "password",
             "email_address",
@@ -109,6 +111,7 @@ class JellyseerrJellyfinSettings(JellyseerrConfigBase):
                 "or set the following attributes so Buildarr can automatically initialise it: "
                 f"{', '.join(repr(f'{tree}.{an}') for an in missing_attrs)}. ",
             )
+
         logger.info("Finished checking if required attributes are defined")
         # Start a session, to store the cookie used during initialisation.
         with requests.Session() as session:

--- a/buildarr_jellyseerr/config/settings/jellyfin.py
+++ b/buildarr_jellyseerr/config/settings/jellyfin.py
@@ -24,6 +24,7 @@ from logging import getLogger
 from typing import Any, Dict, List, Optional, Set, Union, cast
 
 import requests
+
 from buildarr.config import RemoteMapEntry
 from buildarr.types import NonEmptyStr
 from pydantic import AnyHttpUrl, EmailStr, SecretStr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "buildarr-jellyseerr"
-version = "0.3.2"
+version = "0.3.3"
 description = "Jellyseerr media request library application plugin for Buildarr"
 authors = ["Callum Dickinson <callum.dickinson.nz@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
The Jellyseerr API changed, so rather than providing a `hostname` of the form `http(s)://<jellyfin-url>:<port>/<urlBase>`, you instead provide separate fields for `hostname`, `port`, and `urlBase`. This change enables that functionality. Note that this will make old configs invalid, as the `port` and `urlBase` fields are now required.